### PR TITLE
fix: run deploy workflow on all pushes to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'package.json'
-      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Remove path filters from deploy-docs.yml to ensure GitHub Pages deployment happens consistently on every push to main.

This matches the change we made to pr-checks.yml and ensures predictable behavior.